### PR TITLE
Prevents repeat inserts each run and duplicate records if run again for same date

### DIFF
--- a/add_data.py
+++ b/add_data.py
@@ -6,7 +6,7 @@ from main import connect_to_db, CourtCase
 
 def insert_cases(cases):
     query = "INSERT INTO court_cases.court_case (landlord_id, court_date, hearing_type, case_id, county) " \
-            "VALUES (%s, %s, %s, %s, %s)"
+            "VALUES (%s, %s, %s, %s, %s) ON CONFLICT DO NOTHING"
 
     try:
         conn = connect_to_db()
@@ -48,7 +48,7 @@ def get_cases(county, date):
             localdatetime = datetime.strptime(f"{court_date}T{time}", "%m/%d/%YT%I:%M%p")
             utc_dt = local.localize(localdatetime, is_dst=None).astimezone(pytz.utc)
             eviction_cases.append(CourtCase(utc_dt, hearing_type, case_id, landlord, county).get_landlord_id().to_db_tuple())
-    return eviction_cases
+    return set(eviction_cases)
 
 if __name__ == '__main__':
     cases = get_cases('Douglas', '01/15/2021')


### PR DESCRIPTION
Closes #2  

Changed the output of `get_cases()` into a set to remove the duplicate entries caused by the same case being listed multiple times (once for each party involved) on the court calendar.

![Screen Shot 2021-03-20 at 10 25 18 AM](https://user-images.githubusercontent.com/35488541/111878082-9d1bf980-8974-11eb-9b81-1c47424c3988.png)

Additionally, added `ON CONFLICT` clause to the `insert_cases()` query to prevent duplicate entries from being added to the table if run multiple times for the same date. I left it as `DO NOTHING` because I couldn't think of a scenario where it would need to be updated.

Note: To work, this will require a change to the *court_cases.court_case table* to use a composite primary key. I used  `PRIMARY KEY(case_id, court_date)` successfully on my local DB. Unless the goal is to solely capture the number of cases per landlord, case ID cannot be used alone as the primary key because there is a posibility of the same case id being seen on multiple days.

<img width="1098" alt="Screen Shot 2021-03-20 at 9 48 03 AM" src="https://user-images.githubusercontent.com/35488541/111878100-b4f37d80-8974-11eb-9abe-7bc505e7c364.png">
